### PR TITLE
Create variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,28 @@
+# //////////////////////////////
+# VARIABLES
+# //////////////////////////////
+variable "aws_access_key" {}
+
+variable "aws_secret_key" {}
+
+variable "region" {
+  default = "eu-central-1"
+}
+
+variable "instance_count" {
+  type = number
+  default = 1
+}
+
+variable "instance_tags" {
+    type = map
+    default = {
+      "environment" = "dev"
+    }
+}
+# //////////////////////////////
+# OUTPUT
+# //////////////////////////////
+output "instance-ip" {
+  value = module.ec2_cluster.public_ip
+}


### PR DESCRIPTION
Create variables to use later with AWS provider. Use default region value "eu-central-1" for Frankfurt. Tag with default "environment" = "dev" if not set otherwise.